### PR TITLE
feat: add offline mode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.example.location_tracker"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/lib/app/modules/current_location/data/datasources/local_datasource.dart
+++ b/lib/app/modules/current_location/data/datasources/local_datasource.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'package:location_tracker/app/modules/current_location/domain/location_entity.dart';
+import 'package:location_tracker/app/shared/services/cache_service.dart';
+
+import '../../../../shared/utilities/constants.dart';
+
+abstract class LocalDatasource {
+  Future<void> cacheLocation(LocationEntity location);
+  Future<LocationEntity> offlineLocation();
+}
+
+class LocalDatasourceImpl implements LocalDatasource {
+  final CacheService cacheService;
+
+  const LocalDatasourceImpl(this.cacheService);
+
+  @override
+  Future<void> cacheLocation(LocationEntity location) async {
+    final response = await cacheService.cacheRequest(
+      Constants.boxName,
+      location,
+    );
+
+    return response;
+  }
+
+  @override
+  Future<LocationEntity> offlineLocation() async {
+    final result = await cacheService.getRequest(Constants.boxName);
+
+    return result;
+  }
+}

--- a/lib/app/modules/current_location/domain/location_adapter.dart
+++ b/lib/app/modules/current_location/domain/location_adapter.dart
@@ -1,0 +1,25 @@
+import 'package:hive/hive.dart';
+
+import 'location_entity.dart';
+
+class LocationAdapter extends TypeAdapter<LocationEntity> {
+  @override
+  final int typeId = 0; // Unique identifier for the adapter
+
+  @override
+  LocationEntity read(BinaryReader reader) {
+    final latitude = reader.readDouble();
+    final longitude = reader.readDouble();
+
+    return LocationEntity(
+      latitude: latitude,
+      longitude: longitude,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, LocationEntity obj) {
+    writer.writeDouble(obj.latitude);
+    writer.writeDouble(obj.longitude);
+  }
+}

--- a/lib/app/modules/current_location/presentation/screens/current_location_screen.dart
+++ b/lib/app/modules/current_location/presentation/screens/current_location_screen.dart
@@ -93,6 +93,7 @@ class _CurrentLocationScreenState extends State<CurrentLocationScreen> {
                                   target: _location,
                                   zoom: Constants.zoom,
                                 ),
+                                mapType: MapType.normal,
                                 zoomControlsEnabled: false,
                                 myLocationEnabled: false,
                                 myLocationButtonEnabled: false,

--- a/lib/app/shared/services/cache_service.dart
+++ b/lib/app/shared/services/cache_service.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+import 'package:location_tracker/app/modules/current_location/domain/location_entity.dart';
+
+import '../errors/exceptions.dart';
+import '../errors/failure.dart';
+import 'hive_service.dart';
+
+abstract class CacheService {
+  Future<void> cacheRequest(String boxName, LocationEntity location);
+  Future<dynamic> getRequest(String boxName);
+}
+
+class CacheServiceImpl implements CacheService {
+  final HiveService hiveService;
+  const CacheServiceImpl(this.hiveService);
+
+  @override
+  Future<void> cacheRequest(
+    String boxName,
+    dynamic data,
+  ) async {
+    final storage = await hiveService.openBox(boxName);
+
+    try {
+      await storage.put("location", data);
+      debugPrint("Location information cached!");
+    } on HiveError catch (e) {
+      debugPrint("Hive error occurred: $e");
+      throw CacheException(Failure(e.toString()));
+    } on CacheException catch (e) {
+      debugPrint("Cache error occurred: $e");
+      rethrow;
+    } on Exception catch (e) {
+      debugPrint("Unexpected error occurred: $e");
+      throw CacheException(Failure(e.toString()));
+    } finally {
+      try {
+        storage.close();
+      } catch (e) {
+        debugPrint("Error closing $boxName box: $e");
+      }
+    }
+  }
+
+  @override
+  Future<dynamic> getRequest(String boxName) async {
+    final storage = await hiveService.openBox(boxName);
+
+    try {
+      final response = await storage.get("location");
+      return response;
+    } on HiveError catch (e) {
+      debugPrint("Hive error occurred: $e");
+      throw CacheException(Failure(e.toString()));
+    } on CacheException catch (e) {
+      debugPrint("Cache error occurred: $e");
+      rethrow;
+    } on Exception catch (e) {
+      debugPrint("Unexpected error occurred: $e");
+      throw CacheException(Failure(e.toString()));
+    } finally {
+      try {
+        storage.close();
+      } catch (e) {
+        debugPrint("Error closing $boxName box: $e");
+      }
+    }
+  }
+}

--- a/lib/app/shared/services/di_service.dart
+++ b/lib/app/shared/services/di_service.dart
@@ -4,12 +4,15 @@ import 'package:http/http.dart' as http;
 import 'package:location_tracker/app/shared/services/location_service.dart';
 import 'package:location_tracker/app/shared/services/permissions_service.dart';
 
+import '../../modules/current_location/data/datasources/local_datasource.dart';
 import '../../modules/current_location/data/datasources/remote_datasource.dart';
 import '../../modules/current_location/data/location_repository_impl.dart';
 import '../../modules/current_location/domain/location_repository.dart';
 import '../../modules/current_location/domain/location_usecase.dart';
 import '../../modules/current_location/presentation/cubits/cubit.dart';
+import 'cache_service.dart';
 import 'connectivity_service.dart';
+import 'hive_service.dart';
 import 'http_service.dart';
 
 // Service locator (sl)
@@ -28,16 +31,19 @@ Future<void> init() async {
 
   // Repositories
   regSingleton<LocationRepository>(
-    () => LocationRepositoryImpl(sl(), sl(), sl()),
+    () => LocationRepositoryImpl(sl(), sl(), sl(), sl()),
   );
 
   // Datasources
   regSingleton<RemoteDatasource>(() => RemoteDatasourceImpl(sl()));
+  regSingleton<LocalDatasource>(() => LocalDatasourceImpl(sl()));
 
   // Services
   regSingleton<HttpService>(() => HttpServiceImpl());
   regSingleton<LocationService>(() => LocationServiceImpl(sl()));
   regSingleton<PermissionService>(() => PermissionServiceImpl());
+  regSingleton<CacheService>(() => CacheServiceImpl(sl()));
+  regSingleton<HiveService>(() => HiveServiceImpl());
   regSingleton<ConnectivityService>(
     () => ConnectivityServiceImpl(Connectivity()),
   );

--- a/lib/app/shared/services/hive_service.dart
+++ b/lib/app/shared/services/hive_service.dart
@@ -1,0 +1,46 @@
+import 'package:hive/hive.dart';
+
+abstract class HiveService {
+  Future<Box<dynamic>> openBox(String name);
+  Future<void> put(String key, dynamic value);
+  Future<dynamic> get(String key);
+  Future<void> delete(String key);
+  Future<bool> containsKey(String key);
+  Future<void> close();
+}
+
+class HiveServiceImpl implements HiveService {
+  @override
+  Future<Box<dynamic>> openBox(String name) async {
+    return await Hive.openBox(name);
+  }
+
+  @override
+  Future<void> put(String key, dynamic value) async {
+    final box = await openBox(key);
+    await box.put(key, value);
+  }
+
+  @override
+  Future<dynamic> get(String key) async {
+    final box = await openBox(key);
+    return await box.get(key);
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    final box = await openBox(key);
+    await box.delete(key);
+  }
+
+  @override
+  Future<bool> containsKey(String key) async {
+    final box = await openBox(key);
+    return box.containsKey(key);
+  }
+
+  @override
+  Future<void> close() async {
+    await Hive.close();
+  }
+}

--- a/lib/app/shared/utilities/constants.dart
+++ b/lib/app/shared/utilities/constants.dart
@@ -9,6 +9,7 @@ class Constants {
   static const String permissionsDenied = "Location permissions are denied";
   static const String permissionsDeniedPermanently =
       "Location permissions are permanently denied";
+  static const String boxName = "location";
 
   // Doubles
   static const double initLat = 43.6532;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,11 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:hive_flutter/adapters.dart';
 import 'package:location_tracker/app/app.dart';
+import 'package:location_tracker/app/modules/current_location/domain/location_adapter.dart';
+import 'package:path_provider/path_provider.dart';
 
 import 'app/shared/services/di_service.dart' as di;
 import 'app/shared/utilities/env_config.dart';
@@ -13,6 +19,14 @@ void main() async {
 
   // Initialize dependency injectors
   await di.init();
+
+  // Initialize hive and register adapters - for offline support
+  Directory dir = await getApplicationDocumentsDirectory();
+  await Hive.initFlutter(dir.path);
+  Hive.registerAdapter(LocationAdapter());
+
+  // Initialize screen utils - for responsiveness
+  await ScreenUtil.ensureScreenSize();
 
   runApp(const LocationTracker());
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -448,6 +448,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  hive:
+    dependency: "direct main"
+    description:
+      name: hive
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  hive_flutter:
+    dependency: "direct main"
+    description:
+      name: hive_flutter
+      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   html:
     dependency: transitive
     description:
@@ -600,6 +616,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "51f0d2c554cfbc9d6a312ab35152fc77e2f0b758ce9f1a444a3a1e5b8f3c6b7f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -608,6 +672,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -813,6 +885,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: b0f37db61ba2f2e9b7a78a1caece0052564d1bc70668156cf3a29d676fe4e574
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,9 @@ dependencies:
   flutter_screenutil: ^5.9.0
   mockito: ^5.4.4
   build_runner: ^2.4.9
+  hive: ^2.2.3
+  path_provider: ^2.1.3
+  hive_flutter: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,13 +1,23 @@
+import 'dart:io';
+
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/adapters.dart';
 import 'package:location_tracker/app/app.dart';
+import 'package:location_tracker/app/modules/current_location/domain/location_adapter.dart';
 import 'package:location_tracker/app/shared/services/di_service.dart' as di;
+import 'package:path_provider/path_provider.dart';
 
 void main() {
   testWidgets('Should initialize the app', (tester) async {
     TestWidgetsFlutterBinding.ensureInitialized();
 
     di.init();
+
+    // Initialize hive and register adapters - for offline support
+    Directory dir = await getApplicationDocumentsDirectory();
+    await Hive.initFlutter(dir.path);
+    Hive.registerAdapter(LocationAdapter());
 
     await ScreenUtil.ensureScreenSize();
 


### PR DESCRIPTION
Implement offline mode by caching the response from the data source using the `hive` package. A condition was added such that when **only internet is available, API will be used**, **when both internet and GPS are not available, the cached data will be used**, and **when only GPS is available, current GPS location will be used**.